### PR TITLE
Fix race condition

### DIFF
--- a/webmock/context.go
+++ b/webmock/context.go
@@ -1,0 +1,38 @@
+package webmock
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/url"
+)
+
+type Context struct {
+	Req *Req
+}
+
+type Req struct {
+	Method string
+	URL    *url.URL
+	Proto  string
+	Header http.Header
+	Body   []byte
+}
+
+func NewReq(r *http.Request) (*Req, error) {
+	req := new(Req)
+	req.Method = r.Method
+	req.URL = r.URL
+	req.Proto = r.Proto
+	req.Header = make(http.Header, len(r.Header))
+	for k, vs := range r.Header {
+		for _, v := range vs {
+			req.Header.Add(k, v)
+		}
+	}
+	var err error
+	req.Body, err = ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+	return req, nil
+}

--- a/webmock/context.go
+++ b/webmock/context.go
@@ -1,38 +1,7 @@
 package webmock
 
-import (
-	"io/ioutil"
-	"net/http"
-	"net/url"
-)
-
 type Context struct {
-	Req *Req
-}
-
-type Req struct {
-	Method string
-	URL    *url.URL
-	Proto  string
-	Header http.Header
-	Body   []byte
-}
-
-func NewReq(r *http.Request) (*Req, error) {
-	req := new(Req)
-	req.Method = r.Method
-	req.URL = r.URL
-	req.Proto = r.Proto
-	req.Header = make(http.Header, len(r.Header))
-	for k, vs := range r.Header {
-		for _, v := range vs {
-			req.Header.Add(k, v)
-		}
-	}
-	var err error
-	req.Body, err = ioutil.ReadAll(r.Body)
-	if err != nil {
-		return nil, err
-	}
-	return req, nil
+	// RequestBody saves request body as byte buffer.
+	// goproxy.ProxyCtx has Req field, so we do not need to save *http.Request itself.
+	RequestBody []byte
 }


### PR DESCRIPTION
Since webmock-proxy server instances are shared across requests, saving http requests in  the server instance causes race condition.
goproxy provides `UserData` field in request-local context instance.
Using `UserData`, we can save http requests in request-local storage that won't cause race condition.